### PR TITLE
handle duplicated messages from the XCP slave

### DIFF
--- a/pyxcp/examples/xcptest.py
+++ b/pyxcp/examples/xcptest.py
@@ -82,8 +82,8 @@ def test():
     xm.setMta(0x1C0000)
     print("CS:", xm.buildChecksum(4742))
 
-    unlock(xm, 1)
-    verify(xm, 0x1C0000, 128)
+#    unlock(xm, 1)
+#    verify(xm, 0x1C0000, 128)
 
     #print("PS:", xm.programStart()) # ERR_ACCESS_LOCKED
 
@@ -228,6 +228,7 @@ from pprint import pprint
 #import pandas as pd
 
 def bench(xm):
+    import pandas as pd
     result = OrderedDict()
     for pn in range(8, 257, 8):
     #for pn in range(8, 257, 32):

--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -81,7 +81,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
         self.logger = Logger("transport.Base")
         self.logger.setLevel(loglevel)
         self.counterSend = 0
-        self.counterReceived = 0
+        self.counterReceived = -1
         create_daq_timestamps = self.config.get("CREATE_DAQ_TIMESTAMPS")
         self.create_daq_timestamps = False if create_daq_timestamps is None else create_daq_timestamps
         self.timing = Timing()
@@ -231,6 +231,10 @@ class BaseTransport(metaclass=abc.ABCMeta):
         pass
 
     def processResponse(self, response, length, counter, recv_timestamp=None):
+        if counter == self.counterReceived:
+            self.logger.warn("Duplicate message counter {} received from the XCP slave".format(counter))
+            return
+
         self.counterReceived = counter
 
         pid = response[0]

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.10.6"
+__version__ = "0.10.7"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I came across the problem that the XCP slave would sometimes send duplicated messages for the XCP commands. This means that the next XCP command send by the XCP master (pyxcp) would see as reply the duplicated message from the previous command.
