### PR TITLE
use time.time instead of time.perf_counter for the timestamps

### DIFF
--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -97,10 +97,10 @@ class BaseTransport(metaclass=abc.ABCMeta):
 
         self.first_daq_timestamp = None
 
-        self.datetime_origin, self.timestamp_origin = datetime.now(), perf_counter()
-        self.pre_send_timestamp = perf_counter()
-        self.post_send_timestamp = perf_counter()
-        self.recv_timestamp = perf_counter()
+        self.datetime_origin, self.timestamp_origin = datetime.now(), time()
+        self.pre_send_timestamp = time()
+        self.post_send_timestamp = time()
+        self.recv_timestamp = time()
 
     def __del__(self):
         self.finishListener()

--- a/pyxcp/transport/can.py
+++ b/pyxcp/transport/can.py
@@ -30,7 +30,7 @@ import abc
 from collections import OrderedDict
 import functools
 import operator
-from time import perf_counter
+from time import perf_counter, time
 
 from typing import Type
 
@@ -342,9 +342,9 @@ class Can(BaseTransport):
             if len(frame) < 8:
                 frame += b'\x00' * (8 - len(frame))
         # send the request
-        self.pre_send_timestamp = perf_counter()
+        self.pre_send_timestamp = time()
         self.canInterface.transmit(payload=frame)
-        self.post_send_timestamp = perf_counter()
+        self.post_send_timestamp = time()
 
 
     def closeConnection(self):

--- a/pyxcp/transport/eth.py
+++ b/pyxcp/transport/eth.py
@@ -26,7 +26,7 @@ __copyright__ = """
 import selectors
 import socket
 import struct
-from time import perf_counter
+from time import perf_counter, time
 
 from pyxcp.transport.base import BaseTransport
 import pyxcp.types as types
@@ -114,7 +114,7 @@ class Eth(BaseTransport):
                 sel = select(0.1)
                 for _, events in sel:
                     if events & EVENT_READ:
-                        recv_timestamp = perf_counter()
+                        recv_timestamp = time()
                         if use_tcp:
 
                             # first try to get the header in one go
@@ -182,9 +182,9 @@ class Eth(BaseTransport):
                 break
 
     def send(self, frame):
-        self.pre_send_timestamp = perf_counter()
+        self.pre_send_timestamp = time()
         self.sock.send(frame)
-        self.post_send_timestamp = perf_counter()
+        self.post_send_timestamp = time()
 
     def closeConnection(self):
         if not self.invalidSocket:

--- a/pyxcp/transport/sxi.py
+++ b/pyxcp/transport/sxi.py
@@ -24,7 +24,7 @@ __copyright__ = """
 """
 
 import struct
-from time import perf_counter
+from time import perf_counter, time
 
 import serial
 
@@ -91,7 +91,7 @@ class SxI(BaseTransport):
                 return
             if not self.commPort.inWaiting():
                 continue
-            recv_timestamp = perf_counter()
+            recv_timestamp = time()
             length, counter = self.HEADER.unpack(
                 self.commPort.read(self.HEADER_SIZE))
 
@@ -104,9 +104,9 @@ class SxI(BaseTransport):
             self.processResponse(response, length, counter, recv_timestamp)
 
     def send(self, frame):
-        self.pre_send_timestamp = perf_counter()
+        self.pre_send_timestamp = time()
         self.commPort.write(frame)
-        self.post_send_timestamp = perf_counter()
+        self.post_send_timestamp = time()
 
     def closeConnection(self):
         if hasattr(self, "commPort") and self.commPort.isOpen():

--- a/pyxcp/transport/usb_transport.py
+++ b/pyxcp/transport/usb_transport.py
@@ -26,7 +26,7 @@ __copyright__ = """
 import usb.core
 import usb.util
 import struct
-from time import perf_counter, sleep
+from time import perf_counter, sleep, time
 from array import array
 from collections import deque
 
@@ -103,7 +103,7 @@ class Usb(BaseTransport):
                     break
 
                 try:
-                    recv_timestamp = perf_counter()
+                    recv_timestamp = time()
                     read(header, 1)
                 except:
                     sleep(0.001)
@@ -122,9 +122,9 @@ class Usb(BaseTransport):
                 break
 
     def send(self, frame):
-        self.pre_send_timestamp = perf_counter()
+        self.pre_send_timestamp = time()
         self.command_endpoint.write(frame)
-        self.post_send_timestamp = perf_counter()
+        self.post_send_timestamp = time()
 
     def closeConnection(self):
         if self.device is not None:

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Using perf_counter and synchronizing it with datetime is not reliable. Instead use time.time which can be converted into a datetime 
