### PR TITLE
improve hexDump performance

### DIFF
--- a/pyxcp/utils.py
+++ b/pyxcp/utils.py
@@ -43,7 +43,17 @@ import threading
 
 
 def hexDump(arr):
-    return "[{}]".format(' '.join(["{:02x}".format(x) for x in arr]))
+    if isinstance(arr, (bytes, bytearray)):
+        size = len(arr)
+        arr = arr.hex()
+        return "[{}]".format(' '.join([arr[i*2: (i+1)*2] for i in range(size)]))
+    elif isinstance(arr, (list, tuple)):
+        arr = bytes(arr)
+        size = len(arr)
+        arr = arr.hex()
+        return "[{}]".format(' '.join([arr[i*2: (i+1)*2] for i in range(size)]))
+    else:
+        return "[{}]".format(' '.join(["{:02x}".format(x) for x in arr]))
 
 
 def slicer(iterable, sliceLength, converter=None):


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

With this PR the speed is about double compared to the old implementation:
```
data = list(bytes(20))

%timeit hexDump(data)
6.83 µs ± 126 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit hexDump2(data)
4.41 µs ± 331 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

data = tuple(data)

%timeit hexDump(data)
7.03 µs ± 272 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit hexDump2(data)
4.51 µs ± 391 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

data = bytes(data)

%timeit hexDump(data)
6.91 µs ± 149 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit hexDump2(data)
3.83 µs ± 200 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

data = bytearray(data)

%timeit hexDump(data)
7.2 µs ± 163 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

%timeit hexDump2(data)
4.64 µs ± 775 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```