### PR TITLE
exposes the timeout option for the transport layer

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.12
+current_version = 0.13.13
 commit = True
 tag = False
 

--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -273,13 +273,14 @@ class BaseTransport(metaclass=abc.ABCMeta):
                 # self.servQueue.put(response)
                 self.servQueue.append(response)
         else:
-            self.logger.debug(
-                "<- L{} C{} ODT_Data[0:8] {}".format(
-                    length,
-                    counter,
-                    hexDump(response[:8]),
+            if self._debug:
+                self.logger.debug(
+                    "<- L{} C{} ODT_Data[0:8] {}".format(
+                        length,
+                        counter,
+                        hexDump(response[:8]),
+                    )
                 )
-            )
             return
             if self.first_daq_timestamp is None:
                 self.first_daq_timestamp = recv_timestamp

--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -281,7 +281,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
                         hexDump(response[:8]),
                     )
                 )
-            return
+
             if self.first_daq_timestamp is None:
                 self.first_daq_timestamp = recv_timestamp
             if self.create_daq_timestamps:

--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -141,7 +141,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
         try:
             xcpPDU = get(self.resQueue, timeout=self.timeout)
         except Empty:
-            raise types.XcpTimeoutError("Response timed out.") from None
+            raise types.XcpTimeoutError("Response timed out (timeout={}s)".format(self.timeout)) from None
 
         self.timing.stop()
 

--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -27,7 +27,7 @@ import abc
 from collections import deque
 import threading
 from datetime import datetime
-from time import time, sleep, perf_counter
+from time import time, sleep
 
 from ..logger import Logger
 from ..utils import flatten, hexDump
@@ -71,6 +71,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
         #                         Type    Req'd   Default
         "CREATE_DAQ_TIMESTAMPS": (bool,   False,  False),
         "LOGLEVEL":              (str,    False,  "WARN"),
+        "TIMEOUT":               (float,  False,  2.0),
     }
 
     def __init__(self, config=None):
@@ -84,6 +85,8 @@ class BaseTransport(metaclass=abc.ABCMeta):
         self.counterReceived = -1
         create_daq_timestamps = self.config.get("CREATE_DAQ_TIMESTAMPS")
         self.create_daq_timestamps = False if create_daq_timestamps is None else create_daq_timestamps
+        timeout = self.config.get("TIMEOUT")
+        self.timeout = 2.0 if timeout is None else timeout
         self.timing = Timing()
         self.resQueue = deque()
         self.daqQueue = deque()
@@ -136,7 +139,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
         self.send(frame)
 
         try:
-            xcpPDU = get(self.resQueue, timeout=2.0)
+            xcpPDU = get(self.resQueue, timeout=self.timeout)
         except Empty:
             raise types.XcpTimeoutError("Response timed out.") from None
 

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.13.12"
+__version__ = "0.13.13"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This PR exposes the timeout option for the transport layer. 

Especially when working in debug mode, the message processing (hex formatting etc.) can slow down the processing of incoming data to the point were the default 2s timeout is reached.

A new private flag for debug mode is needed for the same reason that formatting the incoming messages is expensive. I've also added the logging of the first 8 bytes of the ODT packets since this can give important information in case of wrong time stamps send by the XCP slave.