### PR TITLE
improve time stamp accuracy

### DIFF
--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -102,7 +102,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
 
         self.first_daq_timestamp = None
 
-        if get_clock_info('time') > 1e-5:
+        if get_clock_info('time').resolution > 1e-5:
             ts, pc = time_perfcounter_correlation()
             self.timestamp_origin = ts
             self.datetime_origin = datetime.fromtimestamp(ts)

--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -102,7 +102,7 @@ class BaseTransport(metaclass=abc.ABCMeta):
 
         self.first_daq_timestamp = None
 
-        if time.get_clock_info('time') > 1e-5:
+        if get_clock_info('time') > 1e-5:
             ts, pc = time_perfcounter_correlation()
             self.timestamp_origin = ts
             self.datetime_origin = datetime.fromtimestamp(ts)

--- a/pyxcp/transport/can.py
+++ b/pyxcp/transport/can.py
@@ -342,10 +342,16 @@ class Can(BaseTransport):
             if len(frame) < 8:
                 frame += b'\x00' * (8 - len(frame))
         # send the request
-        self.pre_send_timestamp = time()
-        self.canInterface.transmit(payload=frame)
-        self.post_send_timestamp = time()
-
+        if self.perf_counter_origin > 0:
+            self.pre_send_timestamp = time()
+            self.canInterface.transmit(payload=frame)
+            self.post_send_timestamp = time()
+        else:
+            pre_send_timestamp = perf_counter()
+            self.canInterface.transmit(payload=frame)
+            post_send_timestamp = perf_counter()
+            self.pre_send_timestamp = self.timestamp_origin + pre_send_timestamp - self.perf_counter_origin
+            self.post_send_timestamp = self.timestamp_origin + post_send_timestamp - self.perf_counter_origin
 
     def closeConnection(self):
         if hasattr(self, "canInterface"):

--- a/pyxcp/utils.py
+++ b/pyxcp/utils.py
@@ -29,7 +29,7 @@ import os
 import sys
 #import subprocess
 import threading
-from time import time, perf_counter
+from time import time, perf_counter, get_clock_info
 
 ##
 ##try:
@@ -136,7 +136,7 @@ def time_perfcounter_correlation():
     """
 
     # use this if the resolution is higher than 10us
-    if time.get_clock_info("time").resolution > 1e-5:
+    if get_clock_info("time").resolution > 1e-5:
         t0 = time()
         while True:
             t1, performance_counter = time(), perf_counter()

--- a/pyxcp/utils.py
+++ b/pyxcp/utils.py
@@ -29,6 +29,7 @@ import os
 import sys
 #import subprocess
 import threading
+from time import time, perf_counter
 
 ##
 ##try:
@@ -115,6 +116,36 @@ else:
         from cStringIO import StringIO
     except ImportError:
         from StringIO import StringIO
+
+
+def time_perfcounter_correlation():
+    """ Get the `perf_counter` value nearest to when time.time() is updated if the `time.time` on
+    this platform has a resolution higher than 10us. This is tipical for the Windows platform
+    were the beste resolution is ~500us.
+
+    On non Windows platforms the current time and perf_counter is directly returned since the
+    resolution is tipical ~1us.
+
+    Note this value is based on when `time.time()` is observed to update from Python, it is not
+    directly returned by the operating system.
+
+    :return:
+        (t, performance_counter) time.time value and perf_counter value when the time.time
+        is updated
+
+    """
+
+    # use this if the resolution is higher than 10us
+    if time.get_clock_info("time").resolution > 1e-5:
+        t0 = time()
+        while True:
+            t1, performance_counter = time(), perf_counter()
+            if t1 != t0:
+                break
+    else:
+        return time(), perf_counter()
+    return t1, performance_counter
+
 
 
 ##

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.13.13"
+__version__ = "0.13.14"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Unix and Linux platforms typically have a high accuracy `time.time` implementation. On Windows the maximum accuracy is ~0.5ms and by default is around 10ms. This information can be checked using ``time.get_clock_info('time').resolution``

This PR provides a way to improve the situation on Windows by  using the utility function to find the value of ``time.perf_counter`` just at the moment when the value of `time.time` is refreshed.
