### PR TITLE
improve Eth transport and add option to disable automatic error handling

### DIFF
--- a/pyxcp/master/__init__.py
+++ b/pyxcp/master/__init__.py
@@ -39,6 +39,6 @@ PRE35 = VERSION.major >= 3 and VERSION.minor < 5
 # We need some pre-3.5 fixes, e.g. flatten() function.
 
 if PRE35:
-    from pyxcp.master.pre35 import Master
+    from .pre35 import Master
 else:
-    from pyxcp.master.py35 import Master
+    from .py35 import Master

--- a/pyxcp/master/__init__.py
+++ b/pyxcp/master/__init__.py
@@ -39,6 +39,6 @@ PRE35 = VERSION.major >= 3 and VERSION.minor < 5
 # We need some pre-3.5 fixes, e.g. flatten() function.
 
 if PRE35:
-    from .pre35 import Master
+    from pyxcp.master.pre35 import Master
 else:
-    from .py35 import Master
+    from pyxcp.master.py35 import Master

--- a/pyxcp/master/errorhandler.py
+++ b/pyxcp/master/errorhandler.py
@@ -386,7 +386,7 @@ def wrapped(func):
     """
     @functools.wraps(func)
     def inner(*args, **kwargs):
-        handle_errors = os.environ.get("PYXCP_HANDLE_ERRORS")
+        handle_errors = os.environ.get("PYXCP_HANDLE_ERRORS", True)
         if handle_errors:
             inst = args[0] # First parameter is 'self'.
             arguments = Arguments(args[ 1 : ], kwargs)

--- a/pyxcp/master/errorhandler.py
+++ b/pyxcp/master/errorhandler.py
@@ -387,12 +387,14 @@ def wrapped(func):
     @functools.wraps(func)
     def inner(*args, **kwargs):
         handle_errors = os.environ.get("PYXCP_HANDLE_ERRORS", True)
+        if handle_errors in (False, "False", "false"):
+            handle_errors = False
         if handle_errors:
             inst = args[0] # First parameter is 'self'.
             arguments = Arguments(args[ 1 : ], kwargs)
             executor = Executor()
             res = executor(inst, func, arguments)
         else:
-            res = func
+            res = func(*args, **kwargs)
         return res
     return inner

--- a/pyxcp/master/errorhandler.py
+++ b/pyxcp/master/errorhandler.py
@@ -32,6 +32,7 @@ import functools
 from pprint import pprint
 
 import sys
+import os
 
 import time
 import threading
@@ -385,9 +386,13 @@ def wrapped(func):
     """
     @functools.wraps(func)
     def inner(*args, **kwargs):
-        inst = args[0] # First parameter is 'self'.
-        arguments = Arguments(args[ 1 : ], kwargs)
-        executor = Executor()
-        res = executor(inst, func, arguments)
+        handle_errors = os.environ.get("PYXCP_HANDLE_ERRORS")
+        if handle_errors:
+            inst = args[0] # First parameter is 'self'.
+            arguments = Arguments(args[ 1 : ], kwargs)
+            executor = Executor()
+            res = executor(inst, func, arguments)
+        else:
+            res = func
         return res
     return inner

--- a/pyxcp/transport/eth.py
+++ b/pyxcp/transport/eth.py
@@ -27,6 +27,7 @@ import selectors
 import socket
 import struct
 from time import perf_counter, time
+import threading
 
 from pyxcp.transport.base import BaseTransport
 import pyxcp.types as types

--- a/pyxcp/transport/eth.py
+++ b/pyxcp/transport/eth.py
@@ -23,6 +23,7 @@ __copyright__ = """
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
+from collections import deque
 import selectors
 import socket
 import struct

--- a/pyxcp/transport/eth.py
+++ b/pyxcp/transport/eth.py
@@ -27,13 +27,14 @@ from collections import deque
 import selectors
 import socket
 import struct
-from time import perf_counter, time
+from time import perf_counter, time, sleep
 import threading
 
 from pyxcp.transport.base import BaseTransport
 import pyxcp.types as types
 
 DEFAULT_XCP_PORT = 5555
+RECV_SIZE = 8196
 
 
 class Eth(BaseTransport):

--- a/pyxcp/utils.py
+++ b/pyxcp/utils.py
@@ -47,7 +47,10 @@ from binascii import hexlify
 def hexDump(arr):
     if isinstance(arr, (bytes, bytearray)):
         size = len(arr)
-        arr = arr.hex()
+        try:
+            arr = arr.hex()
+        except:
+            arr = hexlify(arr).decode('ascii')
         return "[{}]".format(' '.join([arr[i*2: (i+1)*2] for i in range(size)]))
     elif isinstance(arr, (list, tuple)):
         arr = bytes(arr)

--- a/pyxcp/utils.py
+++ b/pyxcp/utils.py
@@ -30,6 +30,7 @@ import sys
 #import subprocess
 import threading
 from time import time, perf_counter, get_clock_info
+from binascii import hexlify
 
 ##
 ##try:
@@ -51,7 +52,10 @@ def hexDump(arr):
     elif isinstance(arr, (list, tuple)):
         arr = bytes(arr)
         size = len(arr)
-        arr = arr.hex()
+        try:
+            arr = arr.hex()
+        except:
+            arr = hexlify(arr).decode('ascii')
         return "[{}]".format(' '.join([arr[i*2: (i+1)*2] for i in range(size)]))
     else:
         return "[{}]".format(' '.join(["{:02x}".format(x) for x in arr]))

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.13.16"
+__version__ = "0.13.17"

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.13.17"
+__version__ = "0.14.0"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### improved Eth transport
I've encountered situation were there are packet drops if the messages are not processed fast enough. It might be that the XCP slave send buffer is small and this makes the problem appear. 
To mitigate this I've added a new thread in the Eth transport that is only responsible for pulling the data from the socket receive buffer into a deque. The listen thread then polls the deque and extracts the XCP messages.
With this change I've seen a 15% CPU (single core) load decrease for a traffic of ~25MB/s

### option to disable automatic error handling
Sometimes the error handling gets in the way, when a direct timeout if preferable for example to avoid wasting time on retry attempts.
The ``PYXCP_HANDLE_ERROR`` environment variable can be used now to select if the automatic error handling is enabled or not
