### PR TITLE
add ALIGNMENT option for XCP commands & handle a false error raised sporadically by some USB slaves

### DIFF
--- a/pyxcp/transport/usb_transport.py
+++ b/pyxcp/transport/usb_transport.py
@@ -196,11 +196,25 @@ class Usb(BaseTransport):
     def send(self, frame):
         if self.perf_counter_origin > 0:
             self.pre_send_timestamp = time()
-            self.command_endpoint.write(frame)
+            try:
+                self.command_endpoint.write(frame)
+            except:
+                # sometimes usb.core.USBError: [Errno 5] Input/Output Error is raised
+                # even though the command is send and a reply is received from the device.
+                # Ignore this here since a Timeout error will be raised anyway if 
+                # the device does not responde
+                pass
             self.post_send_timestamp = time()
         else:
             pre_send_timestamp = perf_counter()
-            self.command_endpoint.write(frame)
+            try:
+                self.command_endpoint.write(frame)
+            except:
+                # sometimes usb.core.USBError: [Errno 5] Input/Output Error is raised
+                # even though the command is send and a reply is received from the device.
+                # Ignore this here since a Timeout error will be raised anyway if 
+                # the device does not responde
+                pass
             post_send_timestamp = perf_counter()
             self.pre_send_timestamp = self.timestamp_origin + pre_send_timestamp - self.perf_counter_origin
             self.post_send_timestamp = self.timestamp_origin + post_send_timestamp - self.perf_counter_origin

--- a/pyxcp/version.py
+++ b/pyxcp/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ pyxcp version module """
 
-__version__ = "0.15.6"
+__version__ = "0.16.0"


### PR DESCRIPTION
The ALIGNMENT general option allows for padding XCP commands with null bytes for devices that expect this kind of behavior (I've only seen this on some USB slaves).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
