### PR TITLE
avoid TypeError: '<' not supported between instances of 'str' and 'int' in pybind11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if has_pybind11:
             sources=["pyxcp/recorder/lz4.cpp", "pyxcp/recorder/wrap.cpp"],
             define_macros=[("EXTENSION_NAME", EXT_NAMES[0]), ("NDEBUG", 1)],
             optional=False,
-            cxx_std="17",
+            cxx_std=17,
         ),
     ]
 else:


### PR DESCRIPTION
…t' in setup_helpers.py from pybin11 for MAC OS

-> change cxx_std type from string to int.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
