### PR TITLE
periodic sleeps to help the receive thread [WIP]

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.53
+current_version = 0.18.54
 commit = True
 tag = False
 

--- a/pyxcp/__init__.py
+++ b/pyxcp/__init__.py
@@ -8,4 +8,4 @@ from .transport import SxI
 from .transport import Usb
 
 # if you update this manually, do not forget to update .bumpversion.cfg
-__version__ = "0.18.53"
+__version__ = "0.18.54"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

The USB communication for some devices is very sensitive to processing delays; if the USB pipe is not read fast enough then buffering errors can occur on the slave device. 

This PR adds a periodic sleep during the processing of the XCP frames to address the problems described above. This way the data listen thread has more chances to execute and pull the data from the slave device. 