### PR TITLE
Bug fixes for generalized downloader and program reset enhancement

### DIFF
--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -1289,9 +1289,12 @@ class Master:
             return None
 
     @wrapped
-    def programReset(self):
+    def programReset(self, wait_for_optional_response=True):
         """Indicate the end of a programming sequence."""
-        return self.transport.request_optional_response(types.Command.PROGRAM_RESET)
+        if wait_for_optional_response:
+            return self.transport.request_optional_response(types.Command.PROGRAM_RESET)
+        else:
+            return self.transport.block_request(types.Command.PROGRAM_RESET)
 
     @wrapped
     def getPgmProcessorInfo(self):

--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -732,7 +732,7 @@ class Master:
             delay(minSt)
 
     @wrapped
-    def download(self, data: bytes, blockModeLength=None, **kwargs):
+    def download(self, data: bytes, blockModeLength=None, last=False):
         """Transfer data from master to slave.
 
         Parameters
@@ -749,7 +749,7 @@ class Master:
         Adress is set via :meth:`setMta`
         """
 
-        if blockModeLength is None:
+        if blockModeLength is None or last:
             # standard mode
             length = len(data)
             response = self.transport.request(types.Command.DOWNLOAD, length, *data)

--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -680,13 +680,21 @@ class Master:
             chunk_size = max_payload
             chunks = range(total_length // chunk_size)
             remaining = total_length % chunk_size
+            percent_complete = 1
+            callback_remaining = total_length
             for _ in chunks:
                 block = data[offset : offset + max_payload]
-                self.download(block, max_payload)
+                dl_func(block, max_payload, last=True)
                 offset += max_payload
+                callback_remaining -= chunk_size
+                if callback and callback_remaining <= total_length - (total_length / 100) * percent_complete:
+                    callback(percent_complete)
+                    percent_complete += 1
             if remaining:
                 block = data[offset : offset + remaining]
-                self.download(block, remaining)
+                dl_func(block, remaining, last=True)
+                if callback:
+                    callback(percent_complete)
 
     def _block_downloader(self, data: bytes, dl_func=None, dl_next_func=None, minSt=0):
         """Re-usable block downloader.


### PR DESCRIPTION
I finally got around to forking the project and adding two bugfixes/enhancements to the generalized downloading concept. I have been using the updates for some time so they are well tested. The enhancement to the program reset method just allows the method to return without waiting for a response. In cases of using the program reset for flashing a new firmware the two second timeout is no significant overhead. However in my case the slave is using the program reset to load up some newly downloaded XCP parameters and this is done very often and the overhead of waiting 2s each time is significant. So if possible I would like to include this enhancement as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.