### PR TITLE
Make the response for the Transport Layer Command optional

### DIFF
--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -499,7 +499,7 @@ class Master:
         ----
         For details refer to XCP specification.
         """
-        return self.transport.request(types.Command.TRANSPORT_LAYER_CMD, subCommand, *data)
+        return self.transport.request_optional_response(types.Command.TRANSPORT_LAYER_CMD, subCommand, *data)
 
     @wrapped
     def userCmd(self, subCommand: int, data: bytes):


### PR DESCRIPTION
Maybe I mis-interpret this but the Transport Layer Command which can be used for a broadcast message to determine if a slave is alive etc. currently does not make the response optional, therefore if the slave does not respond (which seem to be a legitimate use case) an exception is generated. Of course the case for no response can be handled by the higher layers but it seems more elegant to make the response optional, rather than create an exception handler. I did consider a non breaking change by adding an "expect_response" flag to the interface which I could do if you feel this would be better.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
