### PR TITLE
allow only one thread to send/receive XCP commands

### DIFF
--- a/pyxcp/__init__.py
+++ b/pyxcp/__init__.py
@@ -25,4 +25,4 @@ from .transport import SxI
 from .transport import Usb
 
 # if you update this manually, do not forget to update .bumpversion.cfg
-__version__ = "0.20.3"
+__version__ = "0.20.4"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

If two threads are sending XCP commands then it can happen that a thread gets the reply meant for the other one from the respQueue. Using the lock each XCP command is completed before another one can be issued