### PR TITLE
Allow build on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ import sys
 import setuptools.command.build_py
 import setuptools.command.develop
 
+if sys.platform == "darwin":
+    os.environ["CC"] = "clang++"
+    os.environ["CXX"] = "clang++"
+
 try:
     from pybind11.setup_helpers import (
         Pybind11Extension,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The changes introduced in 0.21.0 broke the ability to build this on macOS (running 13.5.2 with newest xcode). This fixes these issues.
- BlockMemory class had a user-defined copy constructor that tried to copy a std::mutex object, which is not allowed. How did this compile on Windows? Regardless the constructor wasn't used here anyways, so I deleted it.
- Sadly, Apple still doesn't fully support C++20 (let alone C++17), so std::jthread is not available.
  - Added proper thread management for std::thread in ~XcpLogFileWriter() (only for apple)
  - Changed creation of collector_thread to std::thread (only for apple)
  - stop_thread() could already handle jthread and thread
- Removed total in XcpLogFileReader.next_block because it was unused and that resulted in a compiler warning
- For some reason pybin11 doesn't pick up on c++, so I had to force it in setup.py. There are several issues in the pybind github but nothing solved. This is the least intrusive workaround.

I only tested it on macOS but it worked fine.