### PR TITLE
fix trying to restart threads when connecting multiple times

### DIFF
--- a/pyxcp/transport/base.py
+++ b/pyxcp/transport/base.py
@@ -216,8 +216,12 @@ class BaseTransport(metaclass=abc.ABCMeta):
         pass
 
     def startListener(self):
-        if not self.listener.is_alive():
-            self.listener.start()
+        if self.listener.is_alive():
+            self.finishListener()
+            self.listener.join()
+
+        self.listener = threading.Thread(target=self.listen)
+        self.listener.start()
 
     def finishListener(self):
         if hasattr(self, "closeEvent"):

--- a/pyxcp/transport/eth.py
+++ b/pyxcp/transport/eth.py
@@ -90,8 +90,11 @@ class Eth(BaseTransport):
             self.status = 1  # connected
 
     def startListener(self):
+        super().startListener()
+        if self._packet_listener.is_alive():
+            self._packet_listener.join()
+        self._packet_listener = threading.Thread(target=self._packet_listen)
         self._packet_listener.start()
-        self.listener.start()
 
     def close(self):
         """Close the transport-layer connection and event-loop."""

--- a/pyxcp/transport/usb_transport.py
+++ b/pyxcp/transport/usb_transport.py
@@ -90,8 +90,11 @@ class Usb(BaseTransport):
         self.status = 1  # connected
 
     def startListener(self):
+        super().startListener()
+        if self._packet_listener.is_alive():
+            self._packet_listener.join()
+        self._packet_listener = threading.Thread(target=self._packet_listen)
         self._packet_listener.start()
-        self.listener.start()
 
     def close(self):
         """Close the transport-layer connection and event-loop."""


### PR DESCRIPTION
When trying to connect e.g. via UDP to a XCP slave which is not responding, the default error handler will try to reconnect infinite times. In some scenarios this is not sensible. Therefore, I've disabled the error handler. 

This unfortunately leads to a ``RuntimeError: threads can only be started once`` from  ``self._packet_listener.start()`` in the ``transport.connect()``

I've fixed this for all the relevant transports, but only verified that it works with the ethernet transport.
Possible repro script:

```python
import threading
import time

import pyxcp

master = pyxcp.Master("eth",
                      config={
                          "HOST": "127.0.0.1",
                          "PROTOCOL": "UDP",
                          "DISABLE_ERROR_HANDLING": True,
                          "LOGLEVEL": "DEBUG"
                      })

for _ in range(5):
    try:
        master.connect()
    except pyxcp.types.XcpTimeoutError as exc:
        print(exc)
```

With the proposed changes it is possible to call the connect multiple times, when the error handler is disabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
