### PR TITLE
restrict counter value to UINT32

### DIFF
--- a/pyxcp/transport/can.py
+++ b/pyxcp/transport/can.py
@@ -321,7 +321,7 @@ class Can(BaseTransport):
         self.processResponse(
             payload,
             len(payload),
-            counter=self.counterReceived + 1,
+            counter=(self.counterReceived + 1) & 0xffff,
             recv_timestamp=recv_timestamp,
         )
 


### PR DESCRIPTION
We set the counter for the CAN transport and it must be a UINT32 value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
