### PR TITLE
add the USB library path as optional configuration parameter for the usb_transport

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.8
+current_version = 0.21.9
 commit = True
 tag = False
 

--- a/pyxcp/__init__.py
+++ b/pyxcp/__init__.py
@@ -25,4 +25,4 @@ from .transport import SxI
 from .transport import Usb
 
 # if you update this manually, do not forget to update .bumpversion.cfg
-__version__ = "0.21.8"
+__version__ = "0.21.9"


### PR DESCRIPTION
The default USB library resolution in pyusb fails if the user needs to use a custom USB library, or if the USB library is not installed system wide. With this PR the user can give the absolute path of the USB library 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
