### PR TITLE
fix cond_unlock for keys that do not fit in a single unlock message

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.9
+current_version = 0.21.10
 commit = True
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "traitlets>=5.9.0",
 ]
 name = "pyxcp"
-version = "0.21.9"
+version = "0.21.10"
 readme = "README.md"
 description = "Universal Calibration Protocol for Python"
 keywords = ["automotive", "ecu", "xcp", "asam", "autosar"]

--- a/pyxcp/__init__.py
+++ b/pyxcp/__init__.py
@@ -25,4 +25,4 @@ from .transport import SxI
 from .transport import Usb
 
 # if you update this manually, do not forget to update .bumpversion.cfg and pyproject.toml
-__version__ = "0.21.9"
+__version__ = "0.21.10"

--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -1809,9 +1809,8 @@ class Master:
                 offset = 0
                 while offset < total_length:
                     data = key[offset : offset + MAX_PAYLOAD]
-                    key_length = len(data)
-                    offset += key_length
-                    self.unlock(key_length, data)
+                    self.unlock(total_length-offset, data)
+                    offset += len(data)
             else:
                 raise SeedNKeyError("SeedAndKey DLL returned: {}".format(SeedNKeyResult(result).name))
 

--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -1790,12 +1790,13 @@ class Master:
             length = result.length
             if length == 0:
                 continue
-            if length > MAX_PAYLOAD:
-                remaining = length - len(seed)
-                while remaining > 0:
-                    result = self.getSeed(types.XcpGetSeedMode.REMAINING, resource_value)
-                    seed.extend(list(result.seed))
-                    remaining = result.length
+
+            while length - len(seed) > 0:
+                result = self.getSeed(types.XcpGetSeedMode.REMAINING, resource_value)
+                seed.extend(list(result.seed))
+
+            seed = seed[: length]  # maybe there are some padding bytes
+
             result, key = getKey(
                 self.logger,
                 self.seedNKeyDLL,


### PR DESCRIPTION
The `UNLOCK` commands must contain the remaining length of the key bytes.

```
MAX_CTO = 8 bytes (CAN)
TotalLengthOf(seed) = 19 bytes
TotalLengthOf(key) = 10 bytes
Seed = 99 88 77 66 55 44 33 22 11 00 11 22 33 44 55 66 77 88 99
Key = 98 76 54 32 10 01 23 45 67 89
```
![image](https://github.com/christoph2/pyxcp/assets/20952040/cdf6ccce-2081-481e-b314-d92db287a9f4)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
