### PR TITLE
Logging fix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  on: workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  on: workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ name: Run tests.
 
 on:
   push:
-    branches: [ master, logging ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,10 +5,9 @@ name: Run tests.
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, logging ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,6 +15,24 @@ General pyXCP Parameters
 * `ALIGNMENT`:                int,      False, 1        -- 1 | 2 | 4, byte alignment.
 * `DISCONNECT_RESPONSE_OPTIONAL`: bool, False, False    -- Don't require response from DISCONNECT service.
 
+Logging:
+^^^^^^^^
+
+When using one of the included examples/scripts, a default logger will be created for console output.
+When used as a library, the application should create log handlers.
+The pyxcp library loggers will be descendents of the base logger with name "pyxcp".
+See: https://docs.python.org/3/howto/logging.html. For example, one can use to create a root logger with defaults (stdout) use::
+
+    import logging
+    logging.basicConfig()
+
+Or, for more specific control::
+
+    import logging
+    logger = logging.getLogger('pyxcp')
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    logger.addHandler(ch)
 
 eth
 ~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,8 +15,8 @@ General pyXCP Parameters
 * `ALIGNMENT`:                int,      False, 1        -- 1 | 2 | 4, byte alignment.
 * `DISCONNECT_RESPONSE_OPTIONAL`: bool, False, False    -- Don't require response from DISCONNECT service.
 
-Logging:
-^^^^^^^^
+Note about LOGLEVEL:
+~~~~~~~~~~~~~~~~~~~~
 
 When using one of the included examples/scripts, a default logger will be created for console output.
 When used as a library, the application should create log handlers.

--- a/pyxcp/cmdline.py
+++ b/pyxcp/cmdline.py
@@ -5,11 +5,13 @@ Parse (transport-layer specific) command line parameters
 and create a XCP master instance.
 """
 import argparse
+import logging
 
 from pyxcp.config import readConfiguration
 from pyxcp.master import Master
 from pyxcp.transport.can import registered_drivers
 from pyxcp.transport.can import try_to_install_system_supplied_drivers
+
 
 try_to_install_system_supplied_drivers()
 
@@ -51,6 +53,9 @@ class ArgumentParser:
 
     def run(self, policy=None):
         """"""
+        # Create a default logging context if run as command line
+        logging.basicConfig()
+
         self._args = self.parser.parse_args()
         args = self.args
         if args.conf is None:

--- a/pyxcp/logger.py
+++ b/pyxcp/logger.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 import logging
 
-logging.basicConfig()
-
-
 class Logger(object):
 
     LOGGER_BASE_NAME = "pyxcp"

--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -18,7 +18,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
-from logger import Logger
 
 from pyxcp import checksum
 from pyxcp import types
@@ -36,6 +35,7 @@ from pyxcp.constants import UnpackerType
 from pyxcp.master.errorhandler import disable_error_handling
 from pyxcp.master.errorhandler import wrapped
 from pyxcp.transport.base import createTransport
+from pyxcp.logger import Logger
 from pyxcp.utils import decode_bytes
 from pyxcp.utils import delay
 from pyxcp.utils import SHORT_SLEEP

--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -8,7 +8,6 @@
 .. [1] XCP Specification, Part 2 - Protocol Layer Specification
 """
 import functools
-import logging
 import struct
 import traceback
 import warnings
@@ -19,6 +18,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
+from logger import Logger
 
 from pyxcp import checksum
 from pyxcp import types
@@ -92,8 +92,7 @@ class Master:
         self.ctr = 0
         self.succeeded = True
         self.config = Configuration(self.PARAMETER_MAP or {}, config or {})
-        self.logger = logging.getLogger("pyXCP")
-        self.logger.setLevel(self.config.get("LOGLEVEL"))
+        self.logger = Logger("master.Master", level=self.config.get("LOGLEVEL"))
         disable_error_handling(self.config.get("DISABLE_ERROR_HANDLING"))
 
         self.transport = createTransport(transportName, config, policy)


### PR DESCRIPTION
Don't calls basicConfig if being used as a library. Logging should be handled by the application, not the library. As it stands now, attempting to import pyXCP will create a root handler which may not be desireable.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
