### PR TITLE
Do no require artifacts for Python 3 embedding developments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(POLICY CMP0135)
 endif()
 cmake_policy(SET CMP0094 NEW)
 
-find_package(Python3 COMPONENTS Interpreter Development)
+find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(pybind11 CONFIG)
 
 SET(CMAKE_C_STANDARD 17)


### PR DESCRIPTION
Fixing build for manylinux images. manylinux images do not include the artifacts for Python 3 embedding developments and those are not required to build this project

https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
