### PR TITLE
Removing the manylinux aarch64 image override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,6 @@ manylinux-aarch64-image = "manylinux_2_35"
 archs = ["x86_64", "aarch64"]
 # before-all = "yum install -y libffi openssl openssl-devel gcc libpython3-dev"
 manylinux-x86_64-image = "manylinux_2_28"
-manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.pyright]
 include = ["pyxcp", "build_ext.py"]


### PR DESCRIPTION
Pulling the manylinux_2_28 aarch64 docker image takes forever. Removing for now. Building using emulation (qemu) would probably be faster. See https://cibuildwheel.pypa.io/en/stable/faq/#emulation

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
