### PR TITLE
Fixed issue with missing argument in call to _generalized_downloader.

### DIFF
--- a/pyxcp/master/master.py
+++ b/pyxcp/master/master.py
@@ -1054,6 +1054,7 @@ class Master:
             dl_func=self.program,
             dl_next_func=self.programNext,
             callback=callback,
+            address_ext=0x00,
         )
 
     def _generalized_downloader(


### PR DESCRIPTION
## Types of changes

This change fixes an issue where an argument was missing from a call to `_generalized_downloader` inside `flash_program` in `Master`. I added the default value 0x00 because the code in the `_generalized_downloader` calls `setMta` which has a default value for `address_ext` of 0x00.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] I have read the **CONTRIBUTING** document.
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

Pytest before change:
======== 3 failed, 309 passed, 4 skipped, 3 warnings in 5.31s ========
====================== short test summary info =======================
FAILED tests/test_master.py::TestMaster::testPagCommands - KeyError: 0
FAILED tests/test_master.py::TestMaster::testPgmCommands - ValueError: non-hexadecimal number found in fromhex() arg at posi...
FAILED tests/test_master.py::TestMaster::testDbgCommands - ValueError: non-hexadecimal number found in fromhex() arg at posi...

Pytest after change:
FAILED tests/test_master.py::TestMaster::testPagCommands - KeyError: 0
FAILED tests/test_master.py::TestMaster::testPgmCommands - ValueError: non-hexadecimal number found in fromhex() arg at posi...
FAILED tests/test_master.py::TestMaster::testDbgCommands - ValueError: non-hexadecimal number found in fromhex() arg at posi...
======== 3 failed, 309 passed, 4 skipped, 3 warnings in 5.28s ========
