### PR TITLE
fix(daq): separate ODT container capacity from max entry size

### DIFF
--- a/pyxcp/daq_stim/__init__.py
+++ b/pyxcp/daq_stim/__init__.py
@@ -154,7 +154,7 @@ class DaqProcessor:
                 # daq_identifier = self.config.Transport.Can.daq_identifier
                 self.transport_layer = self.config.Transport.layer
                 self.pid_off = (
-                    self.config.Transport.Can.pid_off == True
+                    self.config.Transport.Can.pid_off
                 ) and self.transport_layer == "CAN"  # PID_OFF is only available on CAN.
             except (FileNotFoundError, Exception) as e:
                 # Fallback: Create logger when running without config file
@@ -249,7 +249,14 @@ class DaqProcessor:
             else:
                 self.log.debug(f"InterleavedMode disabled: overhead = {overhead} (header={header_len})")
 
-            max_payload_size = min(max_odt_entry_size, max_dto - overhead)
+            # Two independent limits:
+            #   * max_odt_container_size: the total payload capacity of a single ODT (across all
+            #     its entries), bounded by MAX_DTO minus framing overhead.
+            #   * max_entry_size: the maximum size of a single (possibly merged) ODT *entry*
+            #     element, bounded by MAX_ODT_ENTRY_SIZE_DAQ (GET_DAQ_RESOLUTION_INFO). An entry
+            #     can never be larger than what fits in one ODT.
+            max_odt_container_size = max_dto - overhead
+            max_entry_size = min(max_odt_entry_size, max_odt_container_size)
             switch_pid_off: bool = False
             if self.pid_off:
                 if self.supports_pid_off:
@@ -260,20 +267,20 @@ class DaqProcessor:
                         )
                     else:
                         self.log.info("PID_OFF requested and supported.")
-                        max_payload_size += 1
+                        max_odt_container_size += 1
                         switch_pid_off = True
                 else:
                     self.log.info("PID_OFF requested but NOT supported.")
 
-            # First ODT may contain timestamp.
+            # First ODT may contain a timestamp, reducing only its container capacity.
             self.selectable_timestamps = False
-            max_payload_size_first = max_payload_size
+            max_odt_container_size_first = max_odt_container_size
             if not self.supports_timestampes:
                 self.log.info("No timestamp support")
             else:
                 if self.ts_fixed:
                     self.log.debug("Fixed timestamps")
-                    max_payload_size_first = max_payload_size - self.ts_size
+                    max_odt_container_size_first = max_odt_container_size - self.ts_size
                 else:
                     self.log.debug("Variable timestamps.")
                     self.selectable_timestamps = True
@@ -285,13 +292,16 @@ class DaqProcessor:
         for idx, daq_list in enumerate(self.daq_lists):
             if isinstance(daq_list, PredefinedDaqList):
                 continue
+            container_first = max_odt_container_size_first
             if self.selectable_timestamps:
                 if daq_list.enable_timestamps:
-                    max_payload_size_first = max_payload_size - self.ts_size
+                    container_first = max_odt_container_size - self.ts_size
                 else:
-                    max_payload_size_first = max_payload_size
-            ttt = make_continuous_blocks(daq_list.measurements, max_payload_size, max_payload_size_first)
-            daq_list.measurements_opt = first_fit_decreasing(ttt, max_payload_size, max_payload_size_first)
+                    container_first = max_odt_container_size
+            # Per-entry merge cap uses max_entry_size (unaffected by timestamp/PID_OFF); the ODT
+            # bin capacity uses the container size.
+            ttt = make_continuous_blocks(daq_list.measurements, max_entry_size, max_entry_size)
+            daq_list.measurements_opt = first_fit_decreasing(ttt, max_odt_container_size, container_first)
         byte_order = 0 if self.xcp_master.slaveProperties.byteOrder == "INTEL" else 1
         self._first_pids = []
         daq_count = len(self.daq_lists)

--- a/pyxcp/tests/test_daq_odt_packing.py
+++ b/pyxcp/tests/test_daq_odt_packing.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+"""Tests for ODT packing in DaqProcessor.setup().
+
+Verifies that `maxOdtEntrySizeDaq` only caps the size of a single ODT entry, while
+the per-ODT container capacity is `MAX_DTO - overhead`. Measurements should pack up
+to the full container capacity, and the resulting ODT count should grow only when
+the data genuinely exceeds one ODT.
+"""
+
+import logging
+
+from pyxcp.cpp_ext.cpp_ext import DaqList
+
+from pyxcp.daq_stim import DaqProcessor
+
+
+class AttrDict(dict):
+    def __getattr__(self, name):
+        return self[name]
+
+
+# tiny per-entry cap, large DTO.
+DAQ_INFO = {
+    "valid": {"processor": True, "resolution": True, "events": True},
+    "processor": {
+        "keyByte": {
+            "addressExtension": "AE_DIFFERENT_WITHIN_ODT",
+            "identificationField": "IDF_ABS_ODT_NUMBER",
+            "optimisationType": "OM_DEFAULT",
+        },
+        "maxDaq": 2,
+        "minDaq": 0,
+        "properties": {
+            "configType": "DYNAMIC",
+            "pidOffSupported": False,
+            "prescalerSupported": True,
+            "resumeSupported": True,
+            "timestampSupported": False,
+        },
+    },
+    "resolution": {
+        "granularityOdtEntrySizeDaq": 1,
+        "maxOdtEntrySizeDaq": 4,
+        "timestampMode": {"fixed": False, "size": "NO_TIME_STAMP", "unit": "DAQ_TIMESTAMP_UNIT_1MS"},
+        "timestampTicks": 0,
+    },
+}
+
+MAX_ODT = 16  # per A2L DAQ_LIST
+
+
+class MockMaster:
+    def __init__(self):
+        self.slaveProperties = AttrDict({"maxDto": 255, "supportsDaq": True, "byteOrder": "INTEL", "interleavedMode": False})
+        self.alloc_odt_calls = []
+
+    def getDaqInfo(self, include_event_lists=False):
+        return DAQ_INFO
+
+    def freeDaq(self):
+        pass
+
+    def allocDaq(self, daq_count):
+        pass
+
+    def allocOdt(self, daq_num, odt_count):
+        self.alloc_odt_calls.append((daq_num, odt_count))
+
+    def allocOdtEntry(self, daq_num, odt_num, entry_count):
+        pass
+
+    def setDaqPtr(self, *a, **k):
+        pass
+
+    def writeDaq(self, *a, **k):
+        pass
+
+    def setDaqListMode(self, *a, **k):
+        pass
+
+    def startStopDaqList(self, *a, **k):
+        return AttrDict({"firstPid": 0})
+
+
+def _run_setup(measurements):
+    daq_lists = [DaqList("event_1", 0, False, True, measurements)]
+    daq = DaqProcessor(daq_lists, logger=logging.getLogger("test.daq"))
+    daq.pid_off = False
+    daq.xcp_master = MockMaster()
+    daq.set_parameters = lambda *a, **k: None
+    daq.setup()
+    return daq.xcp_master.alloc_odt_calls
+
+
+def test_small_max_odt_entry_size_does_not_inflate_odt_count():
+    """100 non-contiguous 1-byte measurements must pack into a single ODT.
+
+    The entries cannot be merged (addresses are spaced apart), so this exercises
+    pure bin-packing. With a 255-byte DTO the container holds far more than 100
+    one-byte entries, so a single ODT is expected.
+    """
+    measurements = [(f"m{i}", 0x1000 + i * 4, 0, "U8") for i in range(100)]
+    alloc_odt_calls = _run_setup(measurements)
+
+    assert len(alloc_odt_calls) == 1
+    _daq_num, odt_count = alloc_odt_calls[0]
+    assert odt_count == 1
+
+
+def test_measurements_exceeding_one_odt_span_multiple_odts():
+    """Measurements that exceed one ODT's capacity must spill into more ODTs.
+
+    The per-ODT container holds MAX_DTO - overhead = 254 bytes, and each entry is
+    capped at max_entry_size = min(maxOdtEntrySizeDaq=4, 254) = 4 bytes, so 63
+    four-byte entries fit per ODT. Using one more than that (64) must produce a
+    second ODT, confirming the ODT count grows only when the data genuinely
+    outgrows a single ODT.
+    """
+    overhead = 1  # IDF_ABS_ODT_NUMBER, no timestamp, no PID_OFF
+    container = 255 - overhead
+    entry_size = 4
+    entries_per_odt = container // entry_size  # 63
+
+    n = entries_per_odt + 1
+
+    measurements = [(f"m{i}", 0x2000 + i * 8, 0, "U32") for i in range(n)]
+    alloc_odt_calls = _run_setup(measurements)
+
+    assert len(alloc_odt_calls) == 1
+    _daq_num, odt_count = alloc_odt_calls[0]
+    expected = -(-n // entries_per_odt)  # ceil(64 / 63) == 2
+    assert expected == 2
+    assert odt_count == expected


### PR DESCRIPTION

Hi

I have been using DAQ for some time, logging some measurements of my ECU during testing. It has worked well until now when I increased the amount of measurements. I get ERR_MEMORY_OVERFLOW when calling ALLOC_ODT. I'm using pyxcp==0.29.12

This is the details of my ECU
```
MAX_DAQ = 2
MAX_ODT = 16
MAX_DTO = 255
MAX_ODT_ENTRY_SIZE_DAQ = 4
```

This is the sequence i run to trigger the issue

```text
host->ECU  d6                 FREE_DAQ
ECU->host  ff                 OK
host->ECU  d5 00 01 00        ALLOC_DAQ(daq_count=1)
ECU->host  ff                 OK
host->ECU  d4 00 00 00 11     ALLOC_ODT(daq_list=0, odt_count=0x11=17)
ECU->host  fe 30              NAK ERR_MEMORY_OVERFLOW (0x30)
```
So it seems it tries to allocate 17 ODTs instead of maximum 16.  Im only logging ~50 measurements which should fit within those 16 ODTs and 2 DAQLists


I looked into the DaqProcesser.setup() and it seems like MAX_ODT_ENTRY_SIZE_DAQ and MAX_DTO - overhead are conflated. The per-entry size cap is being reused as the per-ODT container capacity. On my ECU where MAX_ODT_ENTRY_SIZE_DAQ (4) is smaller than MAX_DTO - overhead (254), every ODT is limited to 4 bytes, so the measurements get spread across far more ODTs than necessary.

My fix splits them into two separate limits. Added 2 tests as well.

Tested with my ECU with ~120 measurements and it behaves as expected.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X] I have read the **CONTRIBUTING** document.
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. # python test passing but pre-commit --all-files failing on bandit (fixed one old issue with ruff)
